### PR TITLE
update chronology on initial events displayed

### DIFF
--- a/src/state/events/actions.js
+++ b/src/state/events/actions.js
@@ -23,7 +23,7 @@ export const startSetEvents = () => (dispatch) => {
     const events = Object.keys(allevents)
       .map(id => new IndEvent(allevents[id]))
       .filter(evnt => moment(evnt.starts_at).isAfter())
-      .sort((a, b) => (moment(a.starts_at).isAfter(moment(b.starts_at))) ? 1 : -1)
+      .sort((a, b) => (moment(a.starts_at).isSameOrAfter(moment(b.starts_at))) ? 1 : -1)
     return (dispatch(setEvents(events)));
   });
 };

--- a/src/state/events/actions.js
+++ b/src/state/events/actions.js
@@ -23,7 +23,7 @@ export const startSetEvents = () => (dispatch) => {
     const events = Object.keys(allevents)
       .map(id => new IndEvent(allevents[id]))
       .filter(evnt => moment(evnt.starts_at).isAfter())
-      .sort((a, b) => moment(a.starts_at).isSameOrAfter(b.starts_at));
+      .sort((a, b) => (moment(a.starts_at).isAfter(moment(b.starts_at))) ? 1 : -1)
     return (dispatch(setEvents(events)));
   });
 };

--- a/src/state/events/selectors.js
+++ b/src/state/events/selectors.js
@@ -44,7 +44,7 @@ export const getFilteredEvents = createSelector(
         return false;
       }
       return currrentEvent[filterBy].toLowerCase().includes(filterValue.toLowerCase());
-    }).sort((a, b) => (a.starts_at < b.starts_at ? 1 : -1));
+    }).sort((a, b) => (a.starts_at < b.starts_at ? -1 : 1));
   },
 );
 


### PR DESCRIPTION
#124 
PR updates event sort on initial events display in sidebar (makes it chronological)

nice next todo: update chronology sort on any search through searchbar