### PR TITLE
update popover extra color classes style for event map

### DIFF
--- a/src/style/components/_popover.scss
+++ b/src/style/components/_popover.scss
@@ -104,6 +104,24 @@
   }
   @include popover-tip($foreign-policy);
 }
+.popover-dark-green {
+  .mapboxgl-popup-content {
+    @include popover($dark-green);
+  }
+  @include popover-tip($dark-green);
+}
+.popover-dark-purple {
+  .mapboxgl-popup-content {
+    @include popover($dark-purple);
+  }
+  @include popover-tip($dark-purple);
+}
+.popover-dark-orange {
+  .mapboxgl-popup-content {
+    @include popover($dark-orange);
+  }
+  @include popover-tip($dark-orange);
+}
 
 // group popover icons
 .facebook-icon {


### PR DESCRIPTION
this PR adds dark-green, dark-purple, and dark-orange popover style classes.
-will fix current popover colors for Mueller events and election events