### PR TITLE
fix crash on missing zipcode with empty location object

### DIFF
--- a/src/state/selections/actions.js
+++ b/src/state/selections/actions.js
@@ -3,7 +3,7 @@ import superagent from 'superagent';
 import { firebaseUrl } from '../constants';
 
 export const setLatLng = payload => ({
-  payload,
+  payload: payload || {},
   type: 'SET_LAT_LNG',
 });
 


### PR DESCRIPTION
# What

Avoids the map crash seen in #146 by using an empty location when the zipcode search returns `null` by defaulting to an empty object in the `setLatLng` action.

Now there's no crash but there's also no indication that the lookup failed (happy to add that too if that's helpful)

I couldn't find a Contributing Guide so please let me know if this doesn't match the style for this repo.