### PR TITLE
Add error messages for missing zipcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# indivisible-map
+# Indivisible Map
+
+## Local Development
+
+    npm install
+
+    npm run watch

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -9,7 +9,7 @@ class Table extends React.Component {
   constructor(props) {
     super(props);
     this.getColor = this.getColor.bind(this);
-    this.getIconName = this.getIconName.bind(this);    
+    this.getIconName = this.getIconName.bind(this);
   }
 
   getColor(issueFocus) {
@@ -36,6 +36,7 @@ class Table extends React.Component {
       refcode,
       shouldRender,
       type,
+      error,
       selectItem,
     } = this.props;
     if (!shouldRender) {
@@ -51,6 +52,14 @@ class Table extends React.Component {
           <p className="no-results">Looks like there are no events near you right now. You can create your own
             <a href="http://act.indivisible.org/event/local-actions/create/" target="_blank"> here.</a>
           </p>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div id="events-list">
+          <p className="no-results">Sorry, something went wrong. {error}</p>
         </div>
       );
     }
@@ -81,6 +90,7 @@ class Table extends React.Component {
 
 Table.propTypes = {
   colorMap: PropTypes.arrayOf(PropTypes.object),
+  error: PropTypes.string,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   refcode: PropTypes.string,
   selectItem: PropTypes.func,
@@ -90,6 +100,7 @@ Table.propTypes = {
 
 Table.defaultProps = {
   colorMap: [],
+  error: '',
   refcode: '',
   selectItem: () => {},
 };

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -39,6 +39,15 @@ class Table extends React.Component {
       error,
       selectItem,
     } = this.props;
+
+    if (error) {
+      return (
+        <div id="error-message">
+          <p className="no-results">Sorry, something went wrong. {error}</p>
+        </div>
+      );
+    }
+
     if (!shouldRender) {
       return (
         <div id="groups-list">
@@ -52,14 +61,6 @@ class Table extends React.Component {
           <p className="no-results">Looks like there are no events near you right now. You can create your own
             <a href="http://act.indivisible.org/event/local-actions/create/" target="_blank"> here.</a>
           </p>
-        </div>
-      );
-    }
-
-    if (error) {
-      return (
-        <div id="events-list">
-          <p className="no-results">Sorry, something went wrong. {error}</p>
         </div>
       );
     }

--- a/src/components/TableCell.js
+++ b/src/components/TableCell.js
@@ -78,7 +78,7 @@ class TableCell extends React.Component {
         className={`event-cell ${iconName} ${item.issueFocus.toLowerCase().replace(/\W/g, '-')}`}
         key={`${item.id}`}
         title={item.title}
-        extra={[<a className="rsvp-button" target="_blank" href={`${item.rsvpHref}${refcode}`}>rsvp</a>]}
+        extra={[<a key={`${item.id}-rsvp`} className="rsvp-button" target="_blank" href={`${item.rsvpHref}${refcode}`}>rsvp</a>]}
       >
         {groupName}
         <ul>
@@ -126,8 +126,8 @@ class TableCell extends React.Component {
     }
     if (item.email) {
       iconsSocial.push(
-        <React.Fragment>
-          <li key={item.id} >
+        <React.Fragment key={item.id}>
+          <li>
             <a onClick={TableCell.getEmail} id={item.id}>
               <FontAwesomeIcon
                 icon={faEnvelope}

--- a/src/components/WebGlError.js
+++ b/src/components/WebGlError.js
@@ -10,7 +10,7 @@ class WebGlError extends React.Component {
     const { mapType } = this.props;
     return (
       <Alert
-        message={`This map requires webGL to run and you do not currenlty have it enabled, but you can still search for ${mapType}s near you.`}
+        message={`This map requires webGL to run and you do not currently have it enabled, but you can still search for ${mapType}s near you.`}
         type="warning"
         closable
         showIcon

--- a/src/containers/EventsDashboard.js
+++ b/src/containers/EventsDashboard.js
@@ -18,6 +18,7 @@ import {
 } from '../state/events/actions';
 
 import {
+  getError,
   getDistance,
   getLocation,
   getRefCode,
@@ -220,6 +221,7 @@ class EventsDashboard extends React.Component {
       resetSelections,
       searchType,
       filterBy,
+      error,
     } = this.props;
 
     if (this.state.init) {
@@ -244,6 +246,7 @@ class EventsDashboard extends React.Component {
           resetSelections={resetSelections}
           filterBy={filterBy}
           location={center}
+          error={error}
         />
         {this.renderMap()}
         <div className="footer" />
@@ -259,6 +262,7 @@ const mapStateToProps = state => ({
   colorMap: getColorMap(state),
   distance: getDistance(state),
   district: getDistrict(state),
+  error: getError(state),
   eventsByDistrict: getEventsByDistrict(state),
   filterBy: getFilterBy(state),
   filterValue: getFilterValue(state),
@@ -293,6 +297,7 @@ EventsDashboard.propTypes = {
   colorMap: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   distance: PropTypes.number.isRequired,
   district: PropTypes.number,
+  error: PropTypes.string,
   eventsByDistrict: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   filterBy: PropTypes.string,
   filterValue: PropTypes.string,
@@ -319,6 +324,7 @@ EventsDashboard.propTypes = {
 EventsDashboard.defaultProps = {
   center: null,
   district: null,
+  error: '',
   filterBy: 'all',
   filterValue: [],
   refcode: '',

--- a/src/containers/GroupsDashboard.js
+++ b/src/containers/GroupsDashboard.js
@@ -13,6 +13,7 @@ import {
 import { startSetGroups, selectGroup } from '../state/groups/actions';
 
 import {
+  getError,
   getLocation,
   getDistance,
   getFilterBy,
@@ -91,6 +92,7 @@ class GroupsDashboard extends React.Component {
       allGroups,
       groups,
       center,
+      error,
       filterBy,
       resetSelections,
       selectItem,
@@ -100,7 +102,7 @@ class GroupsDashboard extends React.Component {
     }
 
     const containerClass = classNames({
-      'full-width': ((!center.LAT) && (filterBy === 'all')),
+      'full-width': ((!center.LAT) && (filterBy === 'all') && (!error)),
       'groups-container': true,
       'main-container': true,
     });
@@ -115,6 +117,7 @@ class GroupsDashboard extends React.Component {
           selectItem={selectItem}
           filterBy={filterBy}
           location={center}
+          error={error}
         />
         {this.renderMap()}
         <div className="footer" />
@@ -128,6 +131,7 @@ const mapStateToProps = state => ({
   center: getLocation(state),
   colorMap: getColorMap(state),
   distance: getDistance(state),
+  error: getError(state),
   filterBy: getFilterBy(state),
   filterValue: getFilterValue(state),
   groups: getVisbleGroups(state),
@@ -148,6 +152,7 @@ GroupsDashboard.propTypes = {
   center: PropTypes.shape({}).isRequired,
   colorMap: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   distance: PropTypes.number.isRequired,
+  error: PropTypes.string,
   filterBy: PropTypes.string.isRequired,
   filterValue: PropTypes.string.isRequired,
   getInitalGroups: PropTypes.func.isRequired,
@@ -161,6 +166,7 @@ GroupsDashboard.propTypes = {
 };
 
 GroupsDashboard.defaultProps = {
+  error: '',
   selectedGroup: null,
 };
 

--- a/src/containers/SideBar.js
+++ b/src/containers/SideBar.js
@@ -36,6 +36,7 @@ class SideBar extends React.Component {
       refcode,
       selectItem,
       type,
+      error,
     } = this.props;
     return (
       <div className="side-bar-container">
@@ -47,6 +48,7 @@ class SideBar extends React.Component {
           shouldRender={this.renderTable()}
           type={type}
           selectItem={selectItem}
+          error={error}
         />
       </div>
     );
@@ -56,6 +58,7 @@ class SideBar extends React.Component {
 SideBar.propTypes = {
   allItems: PropTypes.arrayOf(PropTypes.object).isRequired,
   colorMap: PropTypes.arrayOf(PropTypes.shape({})),
+  error: PropTypes.string,
   filterBy: PropTypes.string.isRequired,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   location: PropTypes.shape({}).isRequired,
@@ -66,6 +69,7 @@ SideBar.propTypes = {
 
 SideBar.defaultProps = {
   colorMap: [],
+  error: '',
   refcode: '',
   selectItem: () => {},
 };

--- a/src/state/selections/actions.js
+++ b/src/state/selections/actions.js
@@ -64,13 +64,22 @@ export const setInitialFilters = payload => ({
   type: 'SET_INITIAL_FILTERS',
 });
 
+export const setError = payload => ({
+  payload,
+  type: 'SET_ERROR_MESSAGE',
+});
+
 export const getLatLngFromZip = payload => (dispatch) => {
   if (!payload.query) {
     return dispatch(setLatLng({}));
   }
   return superagent.get(`${firebaseUrl}/zips/${payload.query}.json`)
     .then((res) => {
-      dispatch(setLatLng(res.body));
+      if (!res.body) {
+        dispatch(setError(`The ${payload.query} zip code isn't in our database.`));
+      } else {
+        dispatch(setLatLng(res.body));
+      }
     })
-    .catch();
+    .catch(setError('Zip code lookup failed.'));
 };

--- a/src/state/selections/reducers.js
+++ b/src/state/selections/reducers.js
@@ -20,6 +20,7 @@ const filtersReducer = (state = initialState, { type, payload }) => {
       return {
         ...state,
         district: initialState.district,
+        error: initialState.error,
         filterBy: initialState.filterBy,
         filterValue: initialState.filterValue,
         location: initialState.location,
@@ -60,6 +61,7 @@ const filtersReducer = (state = initialState, { type, payload }) => {
     case 'RESET_LAT_LNG':
       return {
         ...state,
+        error: initialState.error,
         location: {},
       };
     case 'SEARCH_BY_KEY_VALUE':

--- a/src/state/selections/reducers.js
+++ b/src/state/selections/reducers.js
@@ -3,6 +3,7 @@ import { uniqBy } from 'lodash';
 const initialState = {
   distance: 50,
   district: NaN,
+  error: '',
   filterBy: 'all',
   filterValue: '',
   filters: 'init',
@@ -53,6 +54,7 @@ const filtersReducer = (state = initialState, { type, payload }) => {
     case 'SET_LAT_LNG':
       return {
         ...state,
+        error: initialState.error,
         location: payload,
       };
     case 'RESET_LAT_LNG':
@@ -90,6 +92,11 @@ const filtersReducer = (state = initialState, { type, payload }) => {
           .map(item => item.issueFocus),
         // turn back on to filter out town halls by default
         // .filter(item => item !== 'Town Hall'),
+      };
+    case 'SET_ERROR_MESSAGE':
+      return {
+        ...state,
+        error: payload,
       };
     default:
       return state;

--- a/src/state/selections/selectors.js
+++ b/src/state/selections/selectors.js
@@ -7,3 +7,4 @@ export const getRefCode = state => state.selections.refcode;
 export const getSearchType = state => state.selections.searchType;
 export const getDistrict = state => state.selections.district;
 export const getSelectedState = state => state.selections.usState;
+export const getError = state => state.selections.error;


### PR DESCRIPTION
Following up on #149 this PR adds more visible error messages so users know when their zipcode does not exist in the townhallproject database:

Error message in the events map:
<img width="1440" alt="Screen Shot 2019-05-09 at 11 50 16 PM" src="https://user-images.githubusercontent.com/7892079/57501833-06ca1780-72b7-11e9-98ba-7bcab802098b.png">

Error message in the groups map:
<img width="1438" alt="Screen Shot 2019-05-09 at 11 49 55 PM" src="https://user-images.githubusercontent.com/7892079/57501836-09c50800-72b7-11e9-9227-488cb8d55444.png">

The error message disappears when a user enters in a new zipcode.

 Also makes smaller changes to avoid a `should have a unique 'key' prop` warning and adds local dev instruction to the README.

@meganrm please let me know if anything I did here does not match the code style for this repo. Happy to change anything!